### PR TITLE
Adds board display to make it easier to view board state

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -5,7 +5,7 @@
 #include "board.h"
 
 typedef std::bitset<64> Bitboard;
-using std::string;
+using namespace std;
 
 const int pKing = 0;
 const int pQueen = 1;
@@ -24,6 +24,65 @@ void Board::update_boards() {
     Board::boardB = Board::pawnB | Board::bishopB | Board::rookB | Board::knightB | Board::kingB | Board:: queenB;
     Board::complete_board = Board::boardW | Board::boardB;
 }
+
+/**
+ Displays a human-readable board
+ */
+string Board::getDisplayString() {
+    vector<pair<string, Bitboard*>> boards = {
+        pair<string, Bitboard*>("♙", &pawnW),
+        pair<string, Bitboard*>("♔", &kingW),
+        pair<string, Bitboard*>("♕", &queenW),
+        pair<string, Bitboard*>("♖", &rookW),
+        pair<string, Bitboard*>("♗", &bishopW),
+        pair<string, Bitboard*>("♘", &knightW),
+        pair<string, Bitboard*>("♟︎", &pawnB),
+        pair<string, Bitboard*>("♚", &kingB),
+        pair<string, Bitboard*>("♛", &queenB),
+        pair<string, Bitboard*>("♜", &rookB),
+        pair<string, Bitboard*>("♝", &bishopB),
+        pair<string, Bitboard*>("♞", &knightB)
+    };
+    
+    // initialize the empty board
+    vector<vector<string>> displayBoard;
+    for(int i=0; i<8; i++) {
+        vector<string> row;
+        
+        for(int j=0; j<8; j++) {
+            row.push_back("_");
+        }
+        displayBoard.push_back(row);
+    }
+    
+    // fill in pieces
+    for(pair<string, Bitboard*> item: boards) {
+        string marker = item.first;
+        Bitboard board = *item.second;
+        
+        for(int i=0; i<board.size(); i++) {
+            if(board[i] == 0) continue;
+            
+            int row = i / 8;
+            int col = i % 8;
+            displayBoard[row][col] = marker;
+        }
+    }
+    
+    // combine into a string
+    string display = "";
+    for(int row=0; row<8; row++) {
+        for(int col=0; col<8; col++) {
+            display += displayBoard[row][col];
+        }
+        if(row != 7) {
+            display += "\n";
+        }
+    }
+     
+    return display;
+}
+
 
 void Board::make_move(int piece, Bitboard move, bool White) {
     if (White) {

--- a/src/board.h
+++ b/src/board.h
@@ -17,6 +17,8 @@ class Board {
     void init_board(string FEN);
     void update_boards();
     void make_move(int piece, Bitboard move, bool White);
+
+    string getDisplayString();
 };
 
 struct Move {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,9 @@ int main() {
     Board board;
     init_eval_center();
     board.init_board(fen_notation);
+    
+    // display the representation of the board we loaded
+    std::cerr << board.getDisplayString() << "\n";
 
     // set_attacking(board, Move(), false);
     // set_attacking(board, Move(), true);
@@ -39,7 +42,12 @@ int main() {
 
     Move move = best_move(board, true, 8);
     display_board(move.move);
+    
     cout << "\n" << move.piece;
+    
+    // now make that move so we can display the updated board
+    board.make_move(move.piece, move.move, true);
+    std::cerr << "\n" << board.getDisplayString() << "\n";
 
     // std::vector<Move> moves = generate_moves(board, true);
     // filter_moves(board, moves, true);


### PR DESCRIPTION
This makes it a little easier to debug board state for someone who
doesn't have intuition about the FEN syntax. It results in displaying
boards like:

r1b1k1nr/p2p1pNp/n2B4/1p1NP2P/6P1/3P1Q2/P1P1K3/q5b1

```
♜_♝_♚_♞♜
♟︎__♟︎_♟︎♘♟︎
♞__♗____
_♟︎_♘♙__♙
______♙_
___♙_♕__
♙_♙_♔___
♛_____♝_
```