### PR TITLE
Movegen test

### DIFF
--- a/src/check_legal.cpp
+++ b/src/check_legal.cpp
@@ -33,6 +33,11 @@ bool check_legal(Board board, Move move, bool White) {
     
     // check pawn moves
     if (move.piece == pPawn) {
+        
+        // check if pawn can move up two
+        if (move.type == PAWN_DOUBLE) {
+            if (!((friendly_board | enemy_board) & move.legal_check).none()) {return false;}
+        }
 
         // check if taking is legal
         if (move.type == PAWN_EAT) {

--- a/src/move_generation.cpp
+++ b/src/move_generation.cpp
@@ -59,9 +59,14 @@ vector<Move> generate_moves(Board board, bool White) {
                     double_move[i] = 1;
                     double_move = double_move >> 16;
                     double_move[i] = 1;
+                    
+                    Bitboard legal_check;
+                    legal_check[i - 8] = 1;
 
                     new_double.move = double_move;
                     new_double.piece = pPawn;
+                    new_double.type = PAWN_DOUBLE;
+                    new_double.legal_check = legal_check;
                     moves.push_back(new_double);
                 }
 
@@ -125,8 +130,13 @@ vector<Move> generate_moves(Board board, bool White) {
                     double_move[i] = 1;
                     double_move[i + 16] = 1;
 
+                    Bitboard legal_check;
+                    legal_check[i + 8] = 1;
+
                     new_double.move = double_move;
                     new_double.piece = pPawn;
+                    new_double.type = PAWN_DOUBLE;
+                    new_double.legal_check = legal_check;
                     moves.push_back(new_double);
                 }
 

--- a/src/move_generation.h
+++ b/src/move_generation.h
@@ -15,6 +15,7 @@ const int pPawn = 5;
 
 const int REGULAR_MOVE = 0;
 const int PAWN_EAT = 1;
+const int PAWN_DOUBLE = 4;
 const int QUEEN_DIAGNOL = 2;
 const int QUEEN_STRAIGHT = 3;
 

--- a/tests/move_generation_test.cpp
+++ b/tests/move_generation_test.cpp
@@ -3,6 +3,7 @@
 #include "move_generation.h"
 #include "eval.h"
 #include "check_legal.h"
+#include "set_attacking.h"
 
 #include <vector>
 
@@ -63,7 +64,7 @@ TEST(MoveGenerationTest, CompareGeneratedMoves) {
 
   // proven number of moves at depth index (depth 0 is really depth 1, or 1 move for white)
   // proven move counts taken from https://en.wikipedia.org/wiki/Shannon_number
-  vector<int> proven_number = {20, 400, 8902, 197281, 4865609, 119060324, 3195901860}
+  vector<int> proven_number = {20, 400, 8902, 197281, 4865609, 119060324}
 
   Board board;
   board.init_board(BoardConstants::DefaultFEN);

--- a/tests/move_generation_test.cpp
+++ b/tests/move_generation_test.cpp
@@ -59,19 +59,37 @@ int possible_moves(Board board, bool isWhite, int depth) {
 }
 
 
-// Compare number of generated moves against proven number at each depth
-TEST(MoveGenerationTest, CompareGeneratedMoves) {
-
-  // proven number of moves at depth index (depth 0 is really depth 1, or 1 move for white)
-  // proven move counts taken from https://en.wikipedia.org/wiki/Shannon_number
-  vector<int> proven_number = {20, 400, 8902, 197281, 4865609, 119060324};
-
+int moves_test(int depth) {
   Board board;
   board.init_board(BoardConstants::DefaultFEN);
-  board.update_boards();
   set_attacking(board);
 
-  for (int i = 0; i < 4; i++) {
-    EXPECT_EQ(possible_moves(board, true, i), proven_number[i]);
-  }
+  return possible_moves(board, true, depth);
+}
+
+// proven move counts taken from https://en.wikipedia.org/wiki/Shannon_number
+
+// depth | move count
+// 1     | 20
+// 2     | 400
+// 3     | 8,902
+// 4     | 197,281
+// 5     | 4,865,609
+// 6     | 119,060,324
+
+// Compare number of generated moves against proven number at each depth (depth 0 = depth 1 or 1 move for white)
+TEST(MoveGenerationTest, CompareGeneratedMovesD1) {
+  EXPECT_EQ(moves_test(0), 20);
+}
+
+TEST(MoveGenerationTest, CompareGeneratedMovesD2) {
+  EXPECT_EQ(moves_test(1), 400);
+}
+
+TEST(MoveGenerationTest, CompareGeneratedMovesD3) {
+  EXPECT_EQ(moves_test(2), 8902);
+}
+
+TEST(MoveGenerationTest, CompareGeneratedMovesD4) {
+  EXPECT_EQ(moves_test(3), 197281);
 }

--- a/tests/move_generation_test.cpp
+++ b/tests/move_generation_test.cpp
@@ -19,6 +19,11 @@ TEST(MoveGenerationTest, CountGeneratedMoves) {
 }
 
 
+Board copy(Board board) {
+  return board;
+}
+
+
 int possible_moves(Board board, bool isWhite, int depth) {
   vector<Move> moves = generate_moves(board, isWhite);
   filter_moves(board, moves, isWhite);
@@ -28,30 +33,33 @@ int possible_moves(Board board, bool isWhite, int depth) {
     int legal_moves = 0;
 
     for (int i = 0; i < moves.size(); i++) {
-      board.make_move(moves[i].piece, moves[i].move, isWhite);
-      set_attacking(board);
+      Board board_copy = copy(board);
+      board_copy.make_move(moves[i].piece, moves[i].move, isWhite);
+      set_attacking(board_copy);
 
-      if (!king_check(board, isWhite)) {
+
+      if (!king_check(board_copy, isWhite)) {
         legal_moves++;
       }
       // undo the move here
-      board.make_move(moves[i].piece, moves[i].move, isWhite);
+      // board.make_move(moves[i].piece, moves[i].move, isWhite);
     }
 
-    return moves.size();
+    return legal_moves;
   }
 
   int found_moves = 0;
 
   for (int i = 0; i < moves.size(); i++) {
-    board.make_move(moves[i].piece, moves[i].move, isWhite);
-    set_attacking(board);
+    Board board_copy = copy(board);
+    board_copy.make_move(moves[i].piece, moves[i].move, isWhite);
+    set_attacking(board_copy);
 
-    if (!king_check(board, isWhite)) {
-      found_moves += possible_moves(board, isWhite == false, depth - 1);
+    if (!king_check(board_copy, isWhite)) {
+      found_moves += possible_moves(board_copy, isWhite == false, depth - 1);
     }
     // undo made move
-    board.make_move(moves[i].piece, moves[i].move, isWhite);
+    // board.make_move(moves[i].piece, moves[i].move, isWhite);
   }
 
   return found_moves;
@@ -86,10 +94,10 @@ TEST(MoveGenerationTest, CompareGeneratedMovesD2) {
   EXPECT_EQ(moves_test(1), 400);
 }
 
-TEST(MoveGenerationTest, DISABLED_CompareGeneratedMovesD3) {
+TEST(MoveGenerationTest, CompareGeneratedMovesD3) {
   EXPECT_EQ(moves_test(2), 8902);
 }
 
-TEST(MoveGenerationTest, DISABLED_CompareGeneratedMovesD4) {
+TEST(MoveGenerationTest, CompareGeneratedMovesD4) {
   EXPECT_EQ(moves_test(3), 197281);
 }

--- a/tests/move_generation_test.cpp
+++ b/tests/move_generation_test.cpp
@@ -86,10 +86,10 @@ TEST(MoveGenerationTest, CompareGeneratedMovesD2) {
   EXPECT_EQ(moves_test(1), 400);
 }
 
-TEST(MoveGenerationTest, CompareGeneratedMovesD3) {
+TEST(MoveGenerationTest, DISABLED_CompareGeneratedMovesD3) {
   EXPECT_EQ(moves_test(2), 8902);
 }
 
-TEST(MoveGenerationTest, CompareGeneratedMovesD4) {
+TEST(MoveGenerationTest, DISABLED_CompareGeneratedMovesD4) {
   EXPECT_EQ(moves_test(3), 197281);
 }

--- a/tests/move_generation_test.cpp
+++ b/tests/move_generation_test.cpp
@@ -64,7 +64,7 @@ TEST(MoveGenerationTest, CompareGeneratedMoves) {
 
   // proven number of moves at depth index (depth 0 is really depth 1, or 1 move for white)
   // proven move counts taken from https://en.wikipedia.org/wiki/Shannon_number
-  vector<int> proven_number = {20, 400, 8902, 197281, 4865609, 119060324}
+  vector<int> proven_number = {20, 400, 8902, 197281, 4865609, 119060324};
 
   Board board;
   board.init_board(BoardConstants::DefaultFEN);

--- a/tests/move_generation_test.cpp
+++ b/tests/move_generation_test.cpp
@@ -2,6 +2,9 @@
 #include "board.h"
 #include "move_generation.h"
 #include "eval.h"
+#include "check_legal.h"
+
+#include <vector>
 
 // Demonstrate some basic assertions.
 TEST(MoveGenerationTest, CountGeneratedMoves) {
@@ -15,3 +18,59 @@ TEST(MoveGenerationTest, CountGeneratedMoves) {
 }
 
 
+int possible_moves(Board board, bool isWhite, int depth) {
+  vector<Move> moves = generate_moves(board, isWhite);
+  filter_moves(board, moves, isWhite);
+
+  if (depth == 0) {
+
+    int legal_moves = 0;
+
+    for (int i = 0; i < moves.size(); i++) {
+      board.make_move(moves[i].piece, moves[i].move, isWhite);
+      set_attacking(board);
+
+      if (!king_check(board, isWhite)) {
+        legal_moves++;
+      }
+      // undo the move here
+      board.make_move(moves[i].piece, moves[i].move, isWhite);
+    }
+
+    return moves.size();
+  }
+
+  int found_moves = 0;
+
+  for (int i = 0; i < moves.size(); i++) {
+    board.make_move(moves[i].piece, moves[i].move, isWhite);
+    set_attacking(board);
+
+    if (!king_check(board, isWhite)) {
+      found_moves += possible_moves(board, isWhite == false, depth - 1);
+    }
+    // undo made move
+    board.make_move(moves[i].piece, moves[i].move, isWhite);
+  }
+
+  return found_moves;
+
+}
+
+
+// Compare number of generated moves against proven number at each depth
+TEST(MoveGenerationTest, CompareGeneratedMoves) {
+
+  // proven number of moves at depth index (depth 0 is really depth 1, or 1 move for white)
+  // proven move counts taken from https://en.wikipedia.org/wiki/Shannon_number
+  vector<int> proven_number = {20, 400, 8902, 197281, 4865609, 119060324, 3195901860}
+
+  Board board;
+  board.init_board(BoardConstants::DefaultFEN);
+  board.update_boards();
+  set_attacking(board);
+
+  for (int i = 0; i < 4; i++) {
+    EXPECT_EQ(possible_moves(board, true, i), proven_number[i]);
+  }
+}


### PR DESCRIPTION
Enables tests for depths 3 and 4, and fixes the bug that caused those tests to fail. This bug was due to pawns being allowed to move up twice even if a piece was blocking them. 