### PR TITLE
Adds CTEST_OUTPUT_ON_FAILURE to get test detail

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -9,6 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CTEST_OUTPUT_ON_FAILURE: 1
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Adds an environment variable CTEST_OUTPUT_ON_FAILURE in order to get more
information when tests fails. It seems like tests are currently failing due to
`vector subscript out of range`. This is a sample block:

```
Test project D:/a/cpp_chess_bot/cpp_chess_bot/build
      Start  1: EvalTest.DefaultBoardValue
 1/19 Test  #1: EvalTest.DefaultBoardValue ....................Exit code 0xc0000409
***Exception:   0.59 sec
Running main() from D:\a\cpp_chess_bot\cpp_chess_bot\build\_deps\googletest-src\googletest\src\gtest_main.cc
Note: Google Test filter = EvalTest.DefaultBoardValue
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from EvalTest
[ RUN      ] EvalTest.DefaultBoardValue
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.29.30037\include\vector(1566) : Assertion failed: vector subscript out of range
```

From: https://github.com/jamiely/cpp_chess_bot/runs/2975630220?check_suite_focus=true#step:4:107

